### PR TITLE
[AP-3669] Remove deprecated set-output command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ for deleting an apply service PRs UAT release.
 ## Workflow example: delete a UAT release when PR on merge
 
 ```yml
+# minimal example that deletes only on branch merge
 name: Delete UAT release on PR merge
 
 on:
@@ -24,12 +25,40 @@ on:
     steps:
       - uses: actions/checkout@v3
       - name: Delete UAT release action
-        uses: uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.0
+        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.0
         with:
           k8s_cluster: ${{ secrets.K8S_CLUSTER }}
           k8s_cluster_cert: ${{ secrets.K8S_CLUSTER_CERT }}
           k8s_namespace: ${{ secrets.K8S_NAMESPACE }}
           k8s_token: ${{ secrets.K8S_TOKEN }}
+```
+
+```yml
+# real world example for deletes on branch merge and close, with output
+# This also supplies the custom release prefix that will be used to
+# identify the release to delete
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete_uat_job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Delete UAT release action
+        id: delete_uat
+        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.0
+        with:
+          release_name_prefix: "apply-"
+          k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}
+          k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}
+          k8s_namespace: ${{ secrets.K8S_GHA_UAT_NAMESPACE }}
+          k8s_token: ${{ secrets.K8S_GHA_UAT_TOKEN }}
+      - name: Result
+        shell: bash
+        run: echo ${{ steps.delete_uat.outputs.delete-message }}
 ```
 
 ## Secrets

--- a/action.yml
+++ b/action.yml
@@ -40,16 +40,17 @@ runs:
           branch=${GITHUB_REF#refs/heads/}
         fi
 
-        echo "##[set-output name=branch;]$(echo $branch)"
+        echo "branch_name=$branch" >> $GITHUB_OUTPUT
 
     - name: Extract release name
       id: extract_release
       shell: bash
       run: |
-        branch=${{ steps.extract_branch.outputs.branch }}
-        truncated_branch=$(echo $branch | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
+        branch_name=${{ steps.extract_branch.outputs.branch_name }}
+        truncated_branch=$(echo $branch_name | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
         prefix=${{ inputs.release_name_prefix }}
-        echo "##[set-output name=release;]$(echo "${prefix}${truncated_branch}")"
+
+        echo "release_name=${prefix}${truncated_branch}" >> $GITHUB_OUTPUT
 
     - name: Authenticate to the cluster
       id: authenticate_to_cluster
@@ -70,13 +71,13 @@ runs:
       id: delete_release
       shell: bash
       run: |
-        release_name=${{ steps.extract_release.outputs.release }}
+        release_name=${{ steps.extract_release.outputs.release_name }}
         found=$(helm list --all | grep $release_name || [[ $? == 1 ]])
 
         if [[ ! -z "$found" ]]
         then
           helm delete $release_name
-          echo "##[set-output name=message;]$(echo "Deleted UAT release ${release_name}!")"
+          echo "message=$(echo "Deleted UAT release ${release_name}!")" >> $GITHUB_OUTPUT
         else
-          echo "##[set-output name=message;]$(echo "UAT release, ${release_name}, not found!")"
+          echo "message=$(echo "UAT release, ${release_name}, not found!")" >> $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
## What
Replace deprecated `set-ouput` command usage in [github action](https://github.com/ministryofjustice/laa-civil-apply-delete-uat-release/blob/main/action.yml) [before the 31st May 2023](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

[link to ticket](https://dsdmoj.atlassian.net/browse/AP-3669)

## Why
Deprecated and EoL on 31/May/2023

- Correct and extend readme examples
- replace set-output with >> $GITHUB_OUTPUT
