### PR TITLE
Correct reference to outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,10 @@ inputs:
 outputs:
   branch-name:
     description: "Extracted branch name"
-    value: ${{ steps.extract_branch.outputs.branch }}
+    value: ${{ steps.extract_branch.outputs.branch_name }}
   release-name:
     description: "Extracted release name"
-    value: ${{ steps.extract_release.outputs.release }}
+    value: ${{ steps.extract_release.outputs.release_name }}
   delete-message:
     description: "Extracted release name"
     value: ${{ steps.delete_release.outputs.message }}


### PR DESCRIPTION
Correct reference to output from steps

v1.0.1 renamed the output variables from `branch` to `branch_name`
and `release` to `release_name` but did not change the reference in the
`outputs:` mapping.
