### PR TITLE
Delete PVC alongside helm uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ for deleting an apply service PRs UAT release.
 - github secrets containing kubernetes credentials for the cluster
 - assumes a certain naming mechanism for UAT release (see deploy script)
 
+## Inputs
+
+| Input               | Description                                                                     |
+|---------------------|---------------------------------------------------------------------------------|
+| release_name_prefix | custom release prefix for the release name to be deleted                        |
+| delete_all_pvc      | `true` to delete all persistenvolumeclaims (PVCs) for any installed helm charts |
+| k8s_cluster         | k8s cluster name                                                                |
+| k8s_cluster_cert    | k8s authentication certificate                                                  |
+| k8s_namespace       | k8s namespace in cluster                                                        |
+| k8s_token           | k8s authentication token                                                        |
+
 ## Workflow example: delete a UAT release when PR on merge
 
 ```yml
@@ -34,9 +45,11 @@ on:
 ```
 
 ```yml
-# real world example for deletes on branch merge and close, with output
-# This also supplies the custom release prefix that will be used to
-# identify the release to delete
+# Real world example for deletes on branch merge and close, with output
+# This also supplies:
+#   - a the custom release prefix that will be used to identify the release to delete
+#   - flag to delete all persistenvolumeclaims (PVCs) for any installed helm charts
+#
 on:
   pull_request:
     types:
@@ -52,6 +65,7 @@ jobs:
         uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.0
         with:
           release_name_prefix: "apply-"
+          delete_all_pvc: true
           k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}
           k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}
           k8s_namespace: ${{ secrets.K8S_GHA_UAT_NAMESPACE }}

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,8 @@ inputs:
     required: true
   release_name_prefix:
     required: false
+  delete_all_pvc:
+    required: false
 outputs:
   branch-name:
     description: "Extracted branch name"
@@ -70,6 +72,8 @@ runs:
     - name: Delete UAT release
       id: delete_release
       shell: bash
+      env:
+        DELETE_ALL_PVC: ${{ inputs.delete_all_pvc }}
       run: |
         release_name=${{ steps.extract_release.outputs.release_name }}
         found=$(helm list --all | grep $release_name || [[ $? == 1 ]])
@@ -77,6 +81,12 @@ runs:
         if [[ ! -z "$found" ]]
         then
           helm delete $release_name
+
+          if [[ "${DELETE_ALL_PVC}" = "true" ]]
+          then
+            kubectl delete pvc -l app.kubernetes.io/instance=$release_name
+          fi
+
           echo "message=$(echo "Deleted UAT release ${release_name}!")" >> $GITHUB_OUTPUT
         else
           echo "message=$(echo "UAT release, ${release_name}, not found!")" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Delete PVC alongside helm uninstall

Helm does not currently delete PVCs when performing
a `helm delete` command. This means they build up 
unnecessarily, eating up cluster resource and cost.

This change implements a delete of any
PVC containing the release name.

It adds an input flag/option that needs to be supplied
with value `true` or `"true"`. This means the version can be released
without changing existing behaviour as the deletion
of PVCs is very destructive and we should probably
not assume all use cases need it, even for UAT
environments. A major version bump might be an alternative
way to handle this.
